### PR TITLE
Fixed 'Next Chapter' URLs at the bottom of pages

### DIFF
--- a/en/chapter01.rst
+++ b/en/chapter01.rst
@@ -187,7 +187,7 @@ Taken together, these pieces loosely follow a pattern called
 Model-View-Controller (MVC). Simply put, MVC is way of developing software so
 that the code for defining and accessing data (the model) is separate from
 request-routing logic (the controller), which in turn is separate from the user
-interface (the view). (We'll discuss MVC in more depth in Chapter 5.)
+interface (the view). (We'll discuss MVC in more depth in `Chapter 5`_.)
 
 A key advantage of such an approach is that components are *loosely coupled*.
 Each distinct piece of a Django-powered Web application has a single key
@@ -198,8 +198,8 @@ HTML without having to touch the Python code that renders it. A database
 administrator can rename a database table and specify the change in a single
 place, rather than having to search and replace through a dozen files.
 
-In this book, each component of MVC gets its own chapter. Chapter 3 covers
-views, Chapter 4 covers templates, and Chapter 5 covers models.
+In this book, each component of MVC gets its own chapter. `Chapter 3`_ covers
+views, `Chapter 4`_ covers templates, and `Chapter 5`_ covers models.
 
 Django's History
 ================
@@ -252,7 +252,7 @@ but it's much more of a collaborative team effort.
 
 This history is relevant because it helps explain two key things. The first is
 Django's "sweet spot." Because Django was born in a news environment, it offers
-several features (such as its admin site, covered in Chapter 6) that are
+several features (such as its admin site, covered in `Chapter 6`_) that are
 particularly well suited for "content" sites -- sites like Amazon.com,
 craigslist.org, and washingtonpost.com that offer dynamic, database-driven
 information. Don't let that turn you off, though -- although Django is
@@ -370,4 +370,8 @@ What's Next
 In the `next chapter`_, we'll get started with Django, covering installation and
 initial setup.
 
+.. _Chapter 5: chapter05.html
+.. _Chapter 4: chapter04.html
+.. _Chapter 6: chapter06.html
+.. _Chapter 3: chapter03.html
 .. _next chapter: chapter02.html

--- a/en/chapter01.rst
+++ b/en/chapter01.rst
@@ -370,4 +370,4 @@ What's Next
 In the `next chapter`_, we'll get started with Django, covering installation and
 initial setup.
 
-.. _next chapter: ../chapter02/
+.. _next chapter: chapter02.html

--- a/en/chapter02.rst
+++ b/en/chapter02.rst
@@ -433,4 +433,4 @@ What's Next?
 Now that you have everything installed and the development server running,
 you're ready to `learn the basics`_ of serving Web pages with Django.
 
-.. _learn the basics: ../chapter03/
+.. _learn the basics: chapter03.html

--- a/en/chapter03.rst
+++ b/en/chapter03.rst
@@ -909,4 +909,4 @@ Django ships with a simple yet powerful template engine that allows you to
 separate the design of the page from the underlying code. We'll dive into
 Django's template engine in the `next chapter`_.
 
-.. _next chapter: ../chapter04/
+.. _next chapter: chapter04.html

--- a/en/chapter04.rst
+++ b/en/chapter04.rst
@@ -1657,4 +1657,4 @@ stored in a relational database. This allows a clean separation of data and logi
 
 The `next chapter`_ covers the tools Django gives you to interact with a database.
 
-.. _next chapter: ../chapter05/
+.. _next chapter: chapter05.html

--- a/en/chapter05.rst
+++ b/en/chapter05.rst
@@ -1383,4 +1383,4 @@ case it would be helpful to have a Web-based interface for entering and
 managing data. The `next chapter`_ covers Django's admin interface, which exists
 precisely for that reason.
 
-.. _next chapter: ../chapter06/
+.. _next chapter: chapter06.html

--- a/en/chapter06.rst
+++ b/en/chapter06.rst
@@ -987,4 +987,4 @@ So far we've created a few models and configured a top-notch interface for
 editing data. In the `next chapter`_, we'll move on to the real "meat and potatoes"
 of Web development: form creation and processing.
 
-.. _next chapter: ../chapter07/
+.. _next chapter: chapter07.html

--- a/en/chapter07.rst
+++ b/en/chapter07.rst
@@ -1282,5 +1282,5 @@ missing pieces as you need them.
 We'll start in `Chapter 8`_ by doubling back and taking a closer look at views
 and URLconfs (introduced first in `Chapter 3`_).
 
-.. _Chapter 3: ../chapter03/
-.. _Chapter 8: ../chapter08/
+.. _Chapter 3: chapter03.html
+.. _Chapter 8: chapter08.html

--- a/en/chapter08.rst
+++ b/en/chapter08.rst
@@ -1130,4 +1130,4 @@ This chapter has provided many advanced tips and tricks for views and URLconfs.
 Next, in `Chapter 9`_, we'll give this advanced treatment to Django's template
 system.
 
-.. _Chapter 9: ../chapter09/
+.. _Chapter 9: chapter09.html

--- a/en/chapter09.rst
+++ b/en/chapter09.rst
@@ -1290,4 +1290,4 @@ What's Next
 Continuing this section's theme of advanced topics, the `next chapter`_ covers
 advanced usage of Django models.
 
-.. _next chapter: ../chapter10/
+.. _next chapter: chapter10.html

--- a/en/chapter10.rst
+++ b/en/chapter10.rst
@@ -598,4 +598,4 @@ What's Next?
 In the `next chapter`_, we'll show you Django's "generic views" framework, which
 lets you save time in building Web sites that follow common patterns.
 
-.. _next chapter: ../chapter11/
+.. _next chapter: chapter11.html

--- a/en/chapter11.rst
+++ b/en/chapter11.rst
@@ -518,4 +518,4 @@ recommended reading if you want to get the most out of this powerful feature.
 This concludes the section of this book devoted to "advanced usage." In the
 `next chapter`_, we cover deployment of Django applications.
 
-.. _next chapter: ../chapter12/
+.. _next chapter: chapter12.html

--- a/en/chapter12.rst
+++ b/en/chapter12.rst
@@ -848,7 +848,7 @@ Of course, selecting memcached does you no good if you don't actually use it.
 framework, and use it everywhere possible. Aggressive, preemptive caching is
 usually the only thing that will keep a site up under major traffic.
 
-.. _Chapter 15: ../chapter15/
+.. _Chapter 15: chapter15.html
 
 Join the Conversation
 ---------------------

--- a/en/chapter13.rst
+++ b/en/chapter13.rst
@@ -986,4 +986,4 @@ Next, we'll continue to dig deeper into the built-in tools Django gives you.
 `Chapter 14`_ looks at all the tools you need to provide user-customized
 sites: sessions, users, and authentication.
 
-.. _Chapter 14: ../chapter14/
+.. _Chapter 14: chapter14.html

--- a/en/chapter14.rst
+++ b/en/chapter14.rst
@@ -1236,4 +1236,4 @@ available.
 In the `next chapter`_, we'll take a look at Django's caching infrastructure,
 which is a convenient way to improve the performance of your application.
 
-.. _next chapter: ../chapter15/
+.. _next chapter: chapter15.html

--- a/en/chapter15.rst
+++ b/en/chapter15.rst
@@ -757,5 +757,9 @@ What's Next?
 
 Django ships with a number of "contrib" packages -- optional features that can
 make your life easier. We've already covered a few of these: the admin site
-(Chapter 6) and the session/user framework (Chapter 14). The next chapter
+(`Chapter 6`_) and the session/user framework (`Chapter 14`_). The `next chapter`_
 covers more of the "contributed" subframeworks.
+
+.. _Chapter 6: chapter06.html
+.. _Chapter 14: chapter14.html
+.. _next chapter: chapter16.html

--- a/en/chapter16.rst
+++ b/en/chapter16.rst
@@ -946,4 +946,4 @@ and/or after every request and can modify requests and responses at will, to
 extend the framework. In the `next chapter`_, we'll discuss Django's built-in
 middleware and explain how you can write your own.
 
-.. _next chapter: ../chapter17/
+.. _next chapter: chapter17.html

--- a/en/chapter17.rst
+++ b/en/chapter17.rst
@@ -389,4 +389,4 @@ Web developers and database-schema designers don't always have the luxury of
 starting from scratch. In the `next chapter`_, we'll cover how to integrate with
 legacy systems, such as database schemas you've inherited from the 1980s.
 
-.. _next chapter: ../chapter18/
+.. _next chapter: chapter18.html

--- a/en/chapter18.rst
+++ b/en/chapter18.rst
@@ -299,4 +299,4 @@ framework (and the hard work of Django's volunteer translators). The
 `next chapter`_ explains how to use this framework to provide localized Django
 sites.
 
-.. _next chapter: ../chapter19/
+.. _next chapter: chapter19.html

--- a/en/chapter19.rst
+++ b/en/chapter19.rst
@@ -940,4 +940,4 @@ What's Next?
 The `final chapter`_ focuses on security -- how you can help secure your sites and
 your users from malicious attackers.
 
-.. _final chapter: ../chapter20/
+.. _final chapter: chapter20.html

--- a/en/chapter20.rst
+++ b/en/chapter20.rst
@@ -516,5 +516,5 @@ your Django projects.
 We wish you the best of luck in running your Django site, whether it's a little
 toy for you and a few friends, or the next Google.
 
-.. _Chapter 14: ../chapter14/
-.. _Chapter 16: ../chapter16/
+.. _Chapter 14: chapter14.html
+.. _Chapter 16: chapter16.html


### PR DESCRIPTION
I noticed on the RTD pages as well as from source, the 'next chapter' urls weren't defined correctly.  I fixed those.  

Also, I started to fix 'Chapter XX' URLs in the book's text.  Perhaps you want these, perhaps not. I didn't go any further than Chapter01.rst before I know if this is something you'd like in the book.  

**disclaimer** First EVER pull request, so perhaps I did this wrong, or my blabbering here is not the right place for this. By all means, blast away! I'm prepared to get my n00b @$$ handed to me.
